### PR TITLE
Implemented Cloudflare Turnstile protection for Payload form submissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,21 @@ CRON_SECRET=YOUR_CRON_SECRET_HERE
 
 # Used to validate preview requests
 PREVIEW_SECRET=YOUR_SECRET_HERE
+
+# S3 storage configuration for media uploads
+S3_BUCKET=your-bucket-name
+
+# AWS or S3-compatible access key ID
+S3_ACCESS_KEY_ID=your-access-key
+
+# AWS or S3-compatible secret access key
+S3_SECRET=your-secret-key
+
+# S3 endpoint URL
+S3_ENDPOINT=your-s3-endpoint 
+
+# Cloudflare Turnstile site key
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key
+
+# Cloudflare Turnstile secret key used for server-side verification
+TURNSTILE_SECRET_KEY=your-turnstile-secret-key

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ S3_ACCESS_KEY_ID=your-access-key
 S3_SECRET=your-secret-key
 
 # S3 endpoint URL
-S3_ENDPOINT=your-s3-endpoint 
+S3_ENDPOINT=your-s3-endpoint
 
 # Cloudflare Turnstile site key
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key

--- a/src/app/(frontend)/contact/_components/Form.tsx
+++ b/src/app/(frontend)/contact/_components/Form.tsx
@@ -99,8 +99,8 @@ export default function Form({ form }: { form: FormWithToast }) {
               res.status ? res.status + ' Error' : 'Error',
               res.errors?.[0]?.message || "We couldn't send your message. Please try again later.",
             )
-              turnstileRef.current?.reset()
-              setCaptchaToken(null)
+            turnstileRef.current?.reset()
+            setCaptchaToken(null)
 
             return
           }

--- a/src/app/(frontend)/contact/_components/Form.tsx
+++ b/src/app/(frontend)/contact/_components/Form.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client'
 import { FormFieldBlock, Form as FormType } from '@payloadcms/plugin-form-builder/types'
 // import { useToast } from '@/components/ui/use-toast';
 import { FormProvider, useForm } from 'react-hook-form'

--- a/src/app/(frontend)/contact/_components/Form.tsx
+++ b/src/app/(frontend)/contact/_components/Form.tsx
@@ -19,7 +19,7 @@ interface FormWithToast extends Omit<FormType, 'confirmationType'> {
 export default function Form({ form }: { form: FormWithToast }) {
   // const [email, setEmail] = useState('')
   // const [name, setName] = useState('')
-  const recaptchaRef = useRef<TurnstileHandle | null>(null)
+  const turnstileRef = useRef<TurnstileHandle | null>(null)
 
   // if (!form) {
   //   return <div>Form not found</div>
@@ -99,7 +99,7 @@ export default function Form({ form }: { form: FormWithToast }) {
               res.status ? res.status + ' Error' : 'Error',
               res.errors?.[0]?.message || "We couldn't send your message. Please try again later.",
             )
-              recaptchaRef.current?.reset()
+              turnstileRef.current?.reset()
               setCaptchaToken(null)
 
             return
@@ -117,14 +117,14 @@ export default function Form({ form }: { form: FormWithToast }) {
             if (redirectUrl) router.push(redirectUrl)
           } else if (form.confirmationType === 'toast' && form.toastMessage) {
             formRef.current?.reset()
-            recaptchaRef.current?.reset()
+            turnstileRef.current?.reset()
             setCaptchaToken(null)
             SuccessToast('Sent!', form.toastMessage)
           }
         } catch (err) {
           console.warn(err)
           setIsLoading(false)
-          recaptchaRef.current?.reset()
+          turnstileRef.current?.reset()
           setCaptchaToken(null)
           // setError({
           //   message: 'Something went wrong.',
@@ -176,7 +176,7 @@ export default function Form({ form }: { form: FormWithToast }) {
           {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ? (
             <div className="mb-6 flex justify-center">
               <TurnstileWidget
-                ref={recaptchaRef}
+                ref={turnstileRef}
                 siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
                 onChange={(token) => setCaptchaToken(token)}
               />

--- a/src/app/(frontend)/contact/_components/Form.tsx
+++ b/src/app/(frontend)/contact/_components/Form.tsx
@@ -1,9 +1,9 @@
-'use client'
+"use client"
 import { FormFieldBlock, Form as FormType } from '@payloadcms/plugin-form-builder/types'
 // import { useToast } from '@/components/ui/use-toast';
 import { FormProvider, useForm } from 'react-hook-form'
-// import ReCAPTCHA from 'react-google-recaptcha';
 import React, { useCallback, useRef, useState } from 'react'
+import TurnstileWidget, { TurnstileHandle } from '@/components/TurnstileWidget'
 import { useRouter } from 'next/navigation'
 import { getClientSideURL } from '@/utilities/getURL'
 import { Button } from '@/components/ui/button'
@@ -19,7 +19,7 @@ interface FormWithToast extends Omit<FormType, 'confirmationType'> {
 export default function Form({ form }: { form: FormWithToast }) {
   // const [email, setEmail] = useState('')
   // const [name, setName] = useState('')
-  // const recaptchaRef = useRef<ReCAPTCHA>(null);
+  const recaptchaRef = useRef<TurnstileHandle | null>(null)
 
   // if (!form) {
   //   return <div>Form not found</div>
@@ -37,6 +37,7 @@ export default function Form({ form }: { form: FormWithToast }) {
   } = formMethods
 
   const [isLoading, setIsLoading] = useState(false)
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   // const [hasSubmitted, setHasSubmitted] = useState<boolean>()
   // const [error, setError] = useState<{ message: string; status?: string } | undefined>()
   const router = useRouter()
@@ -44,6 +45,16 @@ export default function Form({ form }: { form: FormWithToast }) {
 
   const onSubmit = useCallback(
     (data: FormFieldBlock[]) => {
+      if (!process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY) {
+        ErrorToast('Configuration Error', 'CAPTCHA is not configured. Please contact support.')
+        return
+      }
+
+      if (!captchaToken) {
+        ErrorToast('CAPTCHA Required', 'Please complete the CAPTCHA before submitting.')
+        return
+      }
+
       console.log('onSubmit data', data)
       let loadingTimerID: ReturnType<typeof setTimeout>
       const submitForm = async () => {
@@ -68,6 +79,7 @@ export default function Form({ form }: { form: FormWithToast }) {
             }),
             headers: {
               'Content-Type': 'application/json',
+              'x-captcha-token': captchaToken,
             },
             method: 'POST',
           })
@@ -87,6 +99,8 @@ export default function Form({ form }: { form: FormWithToast }) {
               res.status ? res.status + ' Error' : 'Error',
               res.errors?.[0]?.message || "We couldn't send your message. Please try again later.",
             )
+              recaptchaRef.current?.reset()
+              setCaptchaToken(null)
 
             return
           }
@@ -103,11 +117,15 @@ export default function Form({ form }: { form: FormWithToast }) {
             if (redirectUrl) router.push(redirectUrl)
           } else if (form.confirmationType === 'toast' && form.toastMessage) {
             formRef.current?.reset()
+            recaptchaRef.current?.reset()
+            setCaptchaToken(null)
             SuccessToast('Sent!', form.toastMessage)
           }
         } catch (err) {
           console.warn(err)
           setIsLoading(false)
+          recaptchaRef.current?.reset()
+          setCaptchaToken(null)
           // setError({
           //   message: 'Something went wrong.',
           // })
@@ -117,7 +135,7 @@ export default function Form({ form }: { form: FormWithToast }) {
 
       void submitForm()
     },
-    [router, form.id, form.redirect, form.confirmationType, form.toastMessage],
+    [router, form.id, form.redirect, form.confirmationType, form.toastMessage, captchaToken],
   )
 
   return (
@@ -154,6 +172,16 @@ export default function Form({ form }: { form: FormWithToast }) {
                 return null
               })}
           </div>
+
+          {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ? (
+            <div className="mb-6 flex justify-center">
+              <TurnstileWidget
+                ref={recaptchaRef}
+                siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+                onChange={(token) => setCaptchaToken(token)}
+              />
+            </div>
+          ) : null}
 
           <Button
             form={form.id}

--- a/src/blocks/Form/Component.tsx
+++ b/src/blocks/Form/Component.tsx
@@ -2,11 +2,12 @@
 import type { FormFieldBlock, Form as FormType } from '@payloadcms/plugin-form-builder/types'
 
 import { useRouter } from 'next/navigation'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import RichText from '@/components/RichText'
 import { Button } from '@/components/ui/button'
 import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+import TurnstileWidget, { TurnstileHandle } from '@/components/TurnstileWidget'
 
 import { fields } from './fields'
 import { getClientSideURL } from '@/utilities/getURL'
@@ -44,10 +45,28 @@ export const FormBlock: React.FC<
   const [isLoading, setIsLoading] = useState(false)
   const [hasSubmitted, setHasSubmitted] = useState<boolean>()
   const [error, setError] = useState<{ message: string; status?: string } | undefined>()
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const recaptchaRef = useRef<TurnstileHandle | null>(null)
   const router = useRouter()
 
   const onSubmit = useCallback(
     (data: FormFieldBlock[]) => {
+      if (!process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY) {
+        setError({
+          message: 'CAPTCHA is not configured. Please contact support.',
+          status: '500',
+        })
+        return
+      }
+
+      if (!captchaToken) {
+        setError({
+          message: 'Please complete the CAPTCHA before submitting.',
+          status: '400',
+        })
+        return
+      }
+
       let loadingTimerID: ReturnType<typeof setTimeout>
       const submitForm = async () => {
         setError(undefined)
@@ -70,6 +89,7 @@ export const FormBlock: React.FC<
             }),
             headers: {
               'Content-Type': 'application/json',
+              'x-captcha-token': captchaToken,
             },
             method: 'POST',
           })
@@ -85,12 +105,16 @@ export const FormBlock: React.FC<
               message: res.errors?.[0]?.message || 'Internal Server Error',
               status: res.status,
             })
+            recaptchaRef.current?.reset()
+            setCaptchaToken(null)
 
             return
           }
 
           setIsLoading(false)
           setHasSubmitted(true)
+          recaptchaRef.current?.reset()
+          setCaptchaToken(null)
 
           if (confirmationType === 'redirect' && redirect) {
             const { url } = redirect
@@ -105,12 +129,14 @@ export const FormBlock: React.FC<
           setError({
             message: 'Something went wrong.',
           })
+          recaptchaRef.current?.reset()
+          setCaptchaToken(null)
         }
       }
 
       void submitForm()
     },
-    [router, formID, redirect, confirmationType],
+    [router, formID, redirect, confirmationType, captchaToken],
   )
 
   return (
@@ -150,6 +176,16 @@ export const FormBlock: React.FC<
                     return null
                   })}
               </div>
+
+              {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ? (
+                <div className="mb-6 flex justify-center">
+                  <TurnstileWidget
+                    ref={recaptchaRef}
+                    siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+                    onChange={(token) => setCaptchaToken(token)}
+                  />
+                </div>
+              ) : null}
 
               <Button form={formID} type="submit" variant="default">
                 {submitButtonLabel}

--- a/src/blocks/Form/Component.tsx
+++ b/src/blocks/Form/Component.tsx
@@ -46,7 +46,7 @@ export const FormBlock: React.FC<
   const [hasSubmitted, setHasSubmitted] = useState<boolean>()
   const [error, setError] = useState<{ message: string; status?: string } | undefined>()
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
-  const recaptchaRef = useRef<TurnstileHandle | null>(null)
+  const turnstileRef = useRef<TurnstileHandle | null>(null)
   const router = useRouter()
 
   const onSubmit = useCallback(
@@ -105,7 +105,7 @@ export const FormBlock: React.FC<
               message: res.errors?.[0]?.message || 'Internal Server Error',
               status: res.status,
             })
-            recaptchaRef.current?.reset()
+            turnstileRef.current?.reset()
             setCaptchaToken(null)
 
             return
@@ -113,7 +113,7 @@ export const FormBlock: React.FC<
 
           setIsLoading(false)
           setHasSubmitted(true)
-          recaptchaRef.current?.reset()
+          turnstileRef.current?.reset()
           setCaptchaToken(null)
 
           if (confirmationType === 'redirect' && redirect) {
@@ -129,7 +129,7 @@ export const FormBlock: React.FC<
           setError({
             message: 'Something went wrong.',
           })
-          recaptchaRef.current?.reset()
+          turnstileRef.current?.reset()
           setCaptchaToken(null)
         }
       }
@@ -180,7 +180,7 @@ export const FormBlock: React.FC<
               {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ? (
                 <div className="mb-6 flex justify-center">
                   <TurnstileWidget
-                    ref={recaptchaRef}
+                    ref={turnstileRef}
                     siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
                     onChange={(token) => setCaptchaToken(token)}
                   />

--- a/src/components/TurnstileWidget.tsx
+++ b/src/components/TurnstileWidget.tsx
@@ -1,9 +1,21 @@
-"use client"
+'use client'
 import React, { useEffect, useRef, useImperativeHandle } from 'react'
+
+type TurnstileWidgetInstance = {
+  render: (
+    container: HTMLDivElement,
+    options: {
+      sitekey: string
+      callback: (token: string) => void
+      'expired-callback': () => void
+    },
+  ) => number
+  reset: (widgetId: number) => void
+}
 
 declare global {
   interface Window {
-    turnstile?: any
+    turnstile?: TurnstileWidgetInstance
   }
 }
 
@@ -21,7 +33,7 @@ const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
 function loadScript(): Promise<void> {
   return new Promise((resolve) => {
     if (typeof window === 'undefined') return resolve()
-    if ((window as any).turnstile) return resolve()
+    if (window.turnstile) return resolve()
     const existing = document.querySelector(`script[src="${SCRIPT_SRC}"]`)
     if (existing) return resolve()
     const s = document.createElement('script')
@@ -43,7 +55,7 @@ const TurnstileWidget = React.forwardRef<TurnstileHandle, Props>(({ siteKey, onC
         if (typeof window !== 'undefined' && window.turnstile && widgetIdRef.current != null) {
           window.turnstile.reset(widgetIdRef.current)
         }
-      } catch (e) {
+      } catch {
         // ignore
       }
     },
@@ -56,12 +68,18 @@ const TurnstileWidget = React.forwardRef<TurnstileHandle, Props>(({ siteKey, onC
       if (!mounted) return
       if (!containerRef.current) return
       try {
-        widgetIdRef.current = window.turnstile.render(containerRef.current, {
-          sitekey: siteKey,
-          callback: (token: string) => onChange(token),
-          'expired-callback': () => onChange(null),
-        })
-      } catch (e) {
+        const t = typeof window !== 'undefined' ? window.turnstile : undefined
+        if (t && containerRef.current) {
+          widgetIdRef.current = t.render(containerRef.current, {
+            sitekey: siteKey,
+            callback: (token: string) => onChange(token),
+            'expired-callback': () => onChange(null),
+          })
+        } else {
+          // Turnstile not available yet; we'll skip rendering for now
+          // it should be available after the script loads
+        }
+      } catch {
         // script might not be ready; ignore
       }
     })()
@@ -73,5 +91,7 @@ const TurnstileWidget = React.forwardRef<TurnstileHandle, Props>(({ siteKey, onC
 
   return <div ref={containerRef} />
 })
+
+TurnstileWidget.displayName = 'TurnstileWidget'
 
 export default TurnstileWidget

--- a/src/components/TurnstileWidget.tsx
+++ b/src/components/TurnstileWidget.tsx
@@ -34,14 +34,53 @@ function loadScript(): Promise<void> {
   return new Promise((resolve) => {
     if (typeof window === 'undefined') return resolve()
     if (window.turnstile) return resolve()
-    const existing = document.querySelector(`script[src="${SCRIPT_SRC}"]`)
-    if (existing) return resolve()
+
+    const resolveWhenReady = (script: HTMLScriptElement) => {
+      if (window.turnstile) {
+        resolve()
+        return
+      }
+
+      const cleanup = () => {
+        clearInterval(intervalId)
+        script.removeEventListener('load', handleReady)
+        script.removeEventListener('error', handleError)
+      }
+
+      const handleReady = () => {
+        if (!window.turnstile) return
+        cleanup()
+        resolve()
+      }
+
+      const handleError = () => {
+        cleanup()
+        resolve()
+      }
+
+      const intervalId = window.setInterval(() => {
+        if (window.turnstile) {
+          cleanup()
+          resolve()
+        }
+      }, 50)
+
+      script.addEventListener('load', handleReady)
+      script.addEventListener('error', handleError)
+    }
+
+    const existing = document.querySelector(`script[src="${SCRIPT_SRC}"]`) as HTMLScriptElement | null
+    if (existing) {
+      resolveWhenReady(existing)
+      return
+    }
+
     const s = document.createElement('script')
     s.src = SCRIPT_SRC
     s.async = true
     s.defer = true
-    s.onload = () => resolve()
     document.head.appendChild(s)
+    resolveWhenReady(s)
   })
 }
 

--- a/src/components/TurnstileWidget.tsx
+++ b/src/components/TurnstileWidget.tsx
@@ -1,0 +1,77 @@
+"use client"
+import React, { useEffect, useRef, useImperativeHandle } from 'react'
+
+declare global {
+  interface Window {
+    turnstile?: any
+  }
+}
+
+type Props = {
+  siteKey: string
+  onChange: (token: string | null) => void
+}
+
+export type TurnstileHandle = {
+  reset: () => void
+}
+
+const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
+
+function loadScript(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window === 'undefined') return resolve()
+    if ((window as any).turnstile) return resolve()
+    const existing = document.querySelector(`script[src="${SCRIPT_SRC}"]`)
+    if (existing) return resolve()
+    const s = document.createElement('script')
+    s.src = SCRIPT_SRC
+    s.async = true
+    s.defer = true
+    s.onload = () => resolve()
+    document.head.appendChild(s)
+  })
+}
+
+const TurnstileWidget = React.forwardRef<TurnstileHandle, Props>(({ siteKey, onChange }, ref) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const widgetIdRef = useRef<number | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      try {
+        if (typeof window !== 'undefined' && window.turnstile && widgetIdRef.current != null) {
+          window.turnstile.reset(widgetIdRef.current)
+        }
+      } catch (e) {
+        // ignore
+      }
+    },
+  }))
+
+  useEffect(() => {
+    let mounted = true
+    void (async () => {
+      await loadScript()
+      if (!mounted) return
+      if (!containerRef.current) return
+      try {
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: siteKey,
+          callback: (token: string) => onChange(token),
+          'expired-callback': () => onChange(null),
+        })
+      } catch (e) {
+        // script might not be ready; ignore
+      }
+    })()
+
+    return () => {
+      mounted = false
+    }
+  }, [siteKey, onChange])
+
+  return <div ref={containerRef} />
+})
+
+export default TurnstileWidget

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -5,6 +5,8 @@ declare global {
       DATABASE_URI: string
       NEXT_PUBLIC_SERVER_URL: string
       VERCEL_PROJECT_PRODUCTION_URL: string
+      NEXT_PUBLIC_TURNSTILE_SITE_KEY: string
+      TURNSTILE_SECRET_KEY: string
     }
   }
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -10,6 +10,7 @@ import { GenerateTitle, GenerateURL } from '@payloadcms/plugin-seo/types'
 import { FixedToolbarFeature, HeadingFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 import { searchFields } from '@/search/fieldOverrides'
 import { beforeSyncWithSearch } from '@/search/beforeSync'
+import { verifyTurnstileToken } from '@/utilities/verifyTurnstile'
 
 import { Page, Post } from '@/payload-types'
 import { getServerSideURL } from '@/utilities/getURL'
@@ -58,6 +59,23 @@ export const plugins: Plugin[] = [
   formBuilderPlugin({
     fields: {
       payment: false,
+    },
+    formSubmissionOverrides: {
+      hooks: {
+        beforeValidate: [
+          async ({ data, req }) => {
+            const captchaToken = req.headers.get('x-captcha-token') ?? undefined
+
+            const verificationResult = await verifyTurnstileToken(captchaToken)
+
+            if (!verificationResult.success) {
+              throw new Error(verificationResult.message)
+            }
+
+            return data
+          },
+        ],
+      },
     },
     formOverrides: {
       fields: ({ defaultFields }) => {

--- a/src/utilities/verifyTurnstile.ts
+++ b/src/utilities/verifyTurnstile.ts
@@ -36,6 +36,9 @@ export const verifyTurnstileToken = async (
     response: token,
   })
 
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 5000)
+
   try {
     const res = await fetch(turnstileVerifyURL, {
       method: 'POST',
@@ -44,7 +47,9 @@ export const verifyTurnstileToken = async (
       },
       body,
       cache: 'no-store',
+      signal: controller.signal,
     })
+    clearTimeout(timeoutId)
 
     if (!res.ok) {
       return {
@@ -67,6 +72,7 @@ export const verifyTurnstileToken = async (
       message: 'CAPTCHA verified.',
     }
   } catch {
+    clearTimeout(timeoutId)
     return {
       success: false,
       message: 'Turnstile verification service is currently unavailable.',

--- a/src/utilities/verifyTurnstile.ts
+++ b/src/utilities/verifyTurnstile.ts
@@ -1,0 +1,75 @@
+type TurnstileVerificationResponse = {
+  success: boolean
+  challenge_ts?: string
+  hostname?: string
+  'error-codes'?: string[]
+}
+
+type TurnstileVerificationResult = {
+  success: boolean
+  message: string
+}
+
+const turnstileVerifyURL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+export const verifyTurnstileToken = async (
+  token: string | undefined,
+): Promise<TurnstileVerificationResult> => {
+  const secret = process.env.TURNSTILE_SECRET_KEY
+
+  if (!secret) {
+    return {
+      success: false,
+      message: 'Turnstile is not configured on the server.',
+    }
+  }
+
+  if (!token) {
+    return {
+      success: false,
+      message: 'CAPTCHA verification failed. Please complete the CAPTCHA and try again.',
+    }
+  }
+
+  const body = new URLSearchParams({
+    secret,
+    response: token,
+  })
+
+  try {
+    const res = await fetch(turnstileVerifyURL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      cache: 'no-store',
+    })
+
+    if (!res.ok) {
+      return {
+        success: false,
+        message: 'Turnstile verification service is currently unavailable.',
+      }
+    }
+
+    const result = (await res.json()) as TurnstileVerificationResponse
+
+    if (!result.success) {
+      return {
+        success: false,
+        message: 'CAPTCHA verification failed. Please try again.',
+      }
+    }
+
+    return {
+      success: true,
+      message: 'CAPTCHA verified.',
+    }
+  } catch {
+    return {
+      success: false,
+      message: 'Turnstile verification service is currently unavailable.',
+    }
+  }
+}


### PR DESCRIPTION
# Description of Changes

This change adds client-side Turnstile widgets to both form entry points in the app and sends the generated token with each submission request. On the server, form submissions now go through a verification hook before validation, which checks the token against Cloudflare’s Turnstile API and rejects the submission if the token is missing, invalid, or unavailable. The legacy reCAPTCHA dependency and implementation were removed as part of the switch.

## Related Issues

- Closes [ISSUE NUMBER HERE]

## Checklist

- [ ] MR title is meaningful and accurate
- [ ] This MR has an associated GitHub Issues ticket
- [ ] GitHub Issues ticket fix version for this issue is correct
- [ ] ~[Changelog entry](https://keepachangelog.com/en/1.0.0/) has been made~
- [ ] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
